### PR TITLE
fix: data 配下の status / share_id をoptinalに変更

### DIFF
--- a/maker/apis/get_business_publish_status.yaml
+++ b/maker/apis/get_business_publish_status.yaml
@@ -25,7 +25,6 @@ response:
       type: object
       properties:
         status:
-          required: true
           type: string
         post_ids:
           type: array

--- a/maker/apis/post_business_photo_publish.yaml
+++ b/maker/apis/post_business_photo_publish.yaml
@@ -58,5 +58,4 @@ response:
       type: object
       properties:
         share_id:
-          required: true
           type: string

--- a/maker/apis/post_business_video_publish.yaml
+++ b/maker/apis/post_business_video_publish.yaml
@@ -56,5 +56,4 @@ response:
       type: object
       properties:
         share_id:
-          required: true
           type: string

--- a/rust/src/apis/get_business_publish_status.rs
+++ b/rust/src/apis/get_business_publish_status.rs
@@ -69,7 +69,8 @@ impl Response {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Data {
-    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub post_ids: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/rust/src/apis/post_business_photo_publish.rs
+++ b/rust/src/apis/post_business_photo_publish.rs
@@ -116,7 +116,8 @@ impl Response {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Data {
-    pub share_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_id: Option<String>,
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }

--- a/rust/src/apis/post_business_video_publish.rs
+++ b/rust/src/apis/post_business_video_publish.rs
@@ -94,7 +94,8 @@ impl Response {
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct Data {
-    pub share_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub share_id: Option<String>,
     #[serde(flatten)]
     pub extra: std::collections::HashMap<String, serde_json::Value>,
 }


### PR DESCRIPTION
- `get_business_publish_status` の `data.status` を optional 化
- `post_business_photo_publish` の `data.share_id` を optional 化
- `post_business_video_publish` の `data.share_id` を optional 化